### PR TITLE
詳細ページでリロードすると内容が表示されないバグを修正する

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "core-js": "^3.6.5",
     "firebase": "^8.0.0",
     "vue": "^2.6.11",
-    "vue-router": "^3.4.8"
+    "vue-router": "^3.4.8",
+    "vuex": "^3.5.1",
+    "vuex-persistedstate": "^4.0.0-beta.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,10 +6,12 @@
 
 <script>
 import router from './router'
+import store from './store'
 
 export default {
   name: 'App',
   router,
+  store,
 }
 </script>
 

--- a/src/components/Details/DetailsPage.vue
+++ b/src/components/Details/DetailsPage.vue
@@ -35,6 +35,7 @@ export default {
       title: "",
       description: "",
       candidate: "",
+      questionID: "",
     }
   },
   components: {
@@ -44,8 +45,23 @@ export default {
   props: [
     'docID',
   ],
+  computed:{
+    getStoreID(){
+      return this.$store.getters.docID
+    }
+  },
   mounted: function(){
-    var ref = db.collection("Questions").doc(this.docID)
+    if(this.docID == null){
+      //ページリロード
+      //storeから値を取得
+      this.questionID = this.getStoreID
+    } else{
+      //ページ遷移でのアクセス
+      this.questionID = this.docID
+      //storeに値を保存
+      this.$store.dispatch('doUpdate', this.questionID)
+    }
+    var ref = db.collection("Questions").doc(this.questionID)
     // 投稿のタイトルと詳細を取得
     ref.get().then(doc => {
       if(doc.exists){
@@ -66,7 +82,7 @@ export default {
   methods:{
     addAnswer: function(){
       console.log(this.candidate)
-      db.collection('Questions').doc(this.docID).collection('Answers').add({
+      db.collection('Questions').doc(this.questionID).collection('Answers').add({
         text: this.candidate
       })
       .then(() => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,43 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+import createPersistedState from "vuex-persistedstate";
+
+Vue.use(Vuex)
+
+const initialState = {
+  docID: ''
+}
+
+const store = new Vuex.Store({
+  //state:コンポーネントでいうdata
+  state: {
+    initialState
+  },
+
+  //getters:コンポーネントでいうcomputed的なもの
+  getters:{
+    docID(state) {
+      console.log(state.docID)
+      return state.docID
+    }
+  },
+
+  //mutations:コンポーネントでいうmethod（と言うかsetter）
+  //stateを唯一変更できるもの
+  mutations: {
+    //vuexでは引数をpayloadと呼ぶっぽい
+    setDocID(state, payload){
+      state.docID = payload
+    }
+  },
+
+  //actionのコミットを使うことでミューテーションを呼び出す（コンポーネントには無い概念）
+  actions: {
+    doUpdate({commit}, docID){
+      commit('setDocID',docID)
+    }
+  },
+
+  plugins: [createPersistedState()]
+})
+export default store


### PR DESCRIPTION
パッケージを入れたので`npm install`してください

作成者：@Yamakatsu63

## タスク
- [x] Vuexを導入する
- [x] QuestionのドキュメントIDをキャッシュする
- [x] ページリロードされたときに投稿情報を取得する

## テスト
- [x] 詳細ページに遷移してページリロードしても内容が表示されることを確認する
