### PR TITLE
詳細ページの選択肢が表示されないバグの修正

### DIFF
--- a/src/components/CustomHeader.vue
+++ b/src/components/CustomHeader.vue
@@ -60,6 +60,7 @@ export default {
         this.isUserExist = true
         this.userName = user.displayName
         this.initializeUserdb(user)
+        this.$router.go({name: "HomePage"});
       }).catch(function() {
         // ログイン失敗
       });

--- a/src/components/Details/DetailsPage.vue
+++ b/src/components/Details/DetailsPage.vue
@@ -218,6 +218,9 @@ export default {
     },
     isVotedBySelf: function(answerID){
       return new Promise(resolve => {
+        if(this.getUserID == null){
+          resolve(false)
+        }
         db.collection("Users").doc(this.getUserID).collection("Questions").doc(this.questionID)
         .get().then(snapshot => {
           if(snapshot.exists){

--- a/src/components/Details/DetailsPage.vue
+++ b/src/components/Details/DetailsPage.vue
@@ -134,30 +134,8 @@ export default {
       return new Promise(resolve => {
         // 同じ回答に投票していないか確認する
         userRef.get().then(snapshot => {
-          try{
-            var preAnswerId = snapshot.data().answerId
-          } catch{
-            // 初めての投票
-            // 投票する回答に投票数を1増やす
-            dbRef.doc(answerID).get().then(snapshot => {
-              if(snapshot.exists){
-                var num = snapshot.data().votesNum
-                var ansText = snapshot.data().text
-                // 表示する票数を増やす
-                for(var i in this.answers){
-                  if(ansText == this.answers[i].text){
-                    this.answers[i].votes++
-                    this.answers[i].isVoted = !this.answers[i].isVoted
-                  }
-                }
-                dbRef.doc(answerID).update({
-                  votesNum: num+1
-                })
-              resolve(answerID)
-              }
-            })
-          }
           if(snapshot.exists){
+            var preAnswerId = snapshot.data().answerId
             if(preAnswerId != null){
               if(preAnswerId == answerID){
                 // 前回を同じ回答に投票している
@@ -200,6 +178,26 @@ export default {
                 })
               }
             }
+          } else {
+            // 初めての投票
+            // 投票する回答に投票数を1増やす
+            dbRef.doc(answerID).get().then(snapshot => {
+              if(snapshot.exists){
+                var num = snapshot.data().votesNum
+                var ansText = snapshot.data().text
+                // 表示する票数を増やす
+                for(var i in this.answers){
+                  if(ansText == this.answers[i].text){
+                    this.answers[i].votes++
+                    this.answers[i].isVoted = !this.answers[i].isVoted
+                  }
+                }
+                dbRef.doc(answerID).update({
+                  votesNum: num+1
+                })
+              resolve(answerID)
+              }
+            })
           }
         })
       })


### PR DESCRIPTION
# バックログアイテムの情報
close #93 

作成者：@Yamakatsu63

## タスク
- [x] 詳細ページにアクセスしたときのエラーを確認する
- [x] UserテーブルにquestionIDが存在しないときのハンドリングを追加する
