### PR TITLE
ページをリロードすると404エラーがでるバグを修正

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,7 +9,6 @@ import ProfilePage from '../components/Profile/ProfilePage'
 Vue.use(Router)
 
 export default new Router({
-  mode: 'history',
   routes: [
     {
       path: '/',


### PR DESCRIPTION
# バックログアイテムの情報
close #98 

作成者：@Yamakatsu63

## タスク
- [x] firebase.jsonのhostingにrewrite設定を追加してエラーがなくなるか確認する

修正前に`firebase serve`でローカル環境を立ち上げると404のエラーが出ました。
firebase.jsonを修正して、`firebase serve`で再度確認するとエラーがなくなってましたが、
デプロイするとエラーが出ました。

- [x] ルーティングモードをhashモードに変更してエラーがなくなるか確認する

ルーティングモードをhashモードにすると、URLに#が含まれますが、deployしてもうまく動作しました。