### PR TITLE
ログインせずに詳細ページに行くと投票数がNaNになるバグの修正

### DIFF
--- a/src/components/CustomHeader.vue
+++ b/src/components/CustomHeader.vue
@@ -67,6 +67,9 @@ export default {
         var milliDiffTime = now.getTime() - new Date(createAt).getTime()
         var diffYear = Math.floor(milliDiffTime / 1000 / 60 / 60 / 24 / 365)
         this.$store.dispatch('updatePeriodOfGitHub', diffYear)
+        //ページリロード
+        // console.log(this.$route.name)
+        this.$router.go({ name: this.$route.name })
       }).catch(function() {
         // ログイン失敗
       });

--- a/src/components/Details/DetailsPage.vue
+++ b/src/components/Details/DetailsPage.vue
@@ -29,8 +29,10 @@
         <b-button v-on:click="addAnswer" variant="outline-dark">追加する</b-button>
       </b-input-group>
       <div class="section-container vote-btn-container">
-        <div>※あなたの投票で{{pollOfUser}}票入ります</div>
-        <b-button v-on:click="vote" variant="primary">投票する</b-button>
+        <div v-if="userExists">※あなたの投票で{{pollOfUser}}票入ります</div>
+        <b-button v-if="userExists" v-on:click="vote" variant="primary">投票する</b-button>
+        <div v-if="!userExists">※投票するにはログインしてください</div>
+        <b-button v-if="!userExists" disabled v-on:click="vote" variant="primary">投票する</b-button>
       </div>
       <!-- コメント -->
       <div class="section-container">
@@ -60,6 +62,7 @@ export default {
       contributor: "",
       periodOfGitHub: "",
       pollOfUser: 0,
+      userExists: false,
     }
   },
   components: {
@@ -79,7 +82,12 @@ export default {
   },
   mounted: async function(){
     // 自分の投票数を取得
-    this.pollOfUser = Math.floor((this.getPeriodOfGitHub / 2)) + 1
+    if(this.getUserID == ""){
+      this.userExists = false
+    }else {
+      this.userExists = true
+      this.pollOfUser = Math.floor((this.getPeriodOfGitHub / 2)) + 1
+    }
     // URLからドキュメントIDを取得
     this.docID = this.$route.params.id
     var ref = db.collection("Questions").doc(this.docID)
@@ -277,7 +285,7 @@ export default {
     },
     isVotedBySelf: function(answerID){
       return new Promise(resolve => {
-        if(this.getUserID == null){
+        if(this.getUserID == ""){
           resolve(false)
         }
         db.collection("Users").doc(this.getUserID).collection("Questions").doc(this.docID)

--- a/src/components/Details/StarButton.vue
+++ b/src/components/Details/StarButton.vue
@@ -26,16 +26,18 @@ export default {
     // URLからドキュメントIDを取得
     this.docID = this.$route.params.id
     // データベースからスター状態を取得
-    var userRef = db.collection("Users").doc(this.userID).collection("Questions").doc(this.docID)
-    userRef.get().then(snapshot => {
-      if(snapshot.exists){
-        if(snapshot.data().stared != null){
-          this.stared = snapshot.data().stared
+    if(this.userID != ""){
+      var userRef = db.collection("Users").doc(this.userID).collection("Questions").doc(this.docID)
+      userRef.get().then(snapshot => {
+        if(snapshot.exists){
+          if(snapshot.data().stared != null){
+            this.stared = snapshot.data().stared
+          }
+        }else{
+          //投票もお気に入りもしていない
         }
-      }else{
-        //投票もお気に入りもしていない
-      }
-    })
+      })
+    }
   },
   methods:{
     pushStar: function(){

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,17 +4,21 @@ import createPersistedState from "vuex-persistedstate";
 
 Vue.use(Vuex)
 
-const initialState = {
-  docID: '',
-  userID: '',
-  userName: '',
-  periodOfGitHub: '',
-}
+// const initialState = {
+//   docID: '',
+//   userID: '',
+//   userName: '',
+//   periodOfGitHub: 0,
+// }
 
 const store = new Vuex.Store({
   //state:コンポーネントでいうdata
   state: {
-    initialState
+    // initialState
+    docID: '',
+    userID: '',
+    userName: '',
+    periodOfGitHub: 0,
   },
 
   //getters:コンポーネントでいうcomputed的なもの
@@ -29,6 +33,7 @@ const store = new Vuex.Store({
       return state.userName
     },
     periodOfGitHub(state){
+      console.log(state.periodOfGitHub)
       return state.periodOfGitHub
     }
   },


### PR DESCRIPTION
# バックログアイテムの情報
close #121 

作成者：@Yamakatsu

## タスク
- [x] ログインしていない状態で詳細ページに行くと投票数を表示しない
- [x] 投票数を保持する変数の初期値を0にする
- [x] ログイン完了時にページをリロードする
