### PR TITLE
詳細ページのユーザー名をクリックするとその人のユーザーページに遷移できる

### DIFF
--- a/src/components/CustomHeader.vue
+++ b/src/components/CustomHeader.vue
@@ -139,6 +139,7 @@ export default {
         // ページリロード
         // this.$router.go({ name: 'ProfilePage' })
       } else{
+        console.log(this.userID)
         this.$router.push({name: 'ProfilePage', params: {userID: this.userID}});
       }
     },

--- a/src/components/CustomHeader.vue
+++ b/src/components/CustomHeader.vue
@@ -41,6 +41,7 @@ export default {
     return {
       isUserExist: false,
       userName: "",
+      userID: "",
       currentuser: firebase.auth().currentUser,
       loading: true,
     }
@@ -94,6 +95,7 @@ export default {
         console.log("ログイン済み "+ user.displayName)
         this.isUserExist = true
         this.userName = user.displayName
+        this.userID = user.uid
         //storeに値をuserIDを保存
         this.$store.dispatch('updateUserID', user.uid)
         this.$store.dispatch('updateUserName', user.displayName)
@@ -137,7 +139,7 @@ export default {
         // ページリロード
         // this.$router.go({ name: 'ProfilePage' })
       } else{
-        this.$router.push({name: 'ProfilePage'});
+        this.$router.push({name: 'ProfilePage', params: {userID: this.userID}});
       }
     },
   },

--- a/src/components/Details/CommentContent.vue
+++ b/src/components/Details/CommentContent.vue
@@ -33,8 +33,8 @@ export default {
     "userID"
   ],
   computed:{
-    getUserName(){
-      return this.$store.getters.userName
+    getUserID(){
+      return this.$store.getters.userID
     }
   },
   mounted: function(){
@@ -77,7 +77,7 @@ export default {
         db.collection('Questions').doc(this.docID).collection('Comments').add({
           comment: this.commentText,
           time: new Date(),
-          userName: this.getUserName,
+          userID: this.getUserID,
         })
         .then(() => {
             console.log("Document successfully written!")
@@ -134,6 +134,7 @@ export default {
 .user-name-text{
   margin-right: auto;
   -webkit-line-clamp: 1;
+  cursor: pointer;
 }
 
 .time-text{

--- a/src/components/Details/CommentContent.vue
+++ b/src/components/Details/CommentContent.vue
@@ -4,7 +4,7 @@
     <div v-for="(comment, index) in comments" v-bind:key="index">
       <div class="comment-container">
         <div class="comment-title-container">
-          <div v-text="comment.userName" class="user-name-text"></div>
+          <div v-text="comment.userName" v-on:click="toProfilePage(comment.userID)" class="user-name-text"></div>
           <div v-text="comment.time" class="time-text"></div>
         </div>
         <div v-text="comment.text" class="comment-text"></div>
@@ -48,12 +48,21 @@ export default {
       }
       snapshot.forEach(doc => {
         //コメント情報を配列で所持する
-        var commentData = {
-          text: doc.data().comment,
-          userName: doc.data().userName + "さん",
-          time: this.formatDate(new Date(doc.data().time.seconds * 1000)),
-        }
-        this.comments.push(commentData)
+        var otherUserID = doc.data().userID
+        var otherUserName
+        db.collection('Users').doc(doc.data().userID).get().then(snapshot =>{
+          if(snapshot.exists){
+            otherUserName = snapshot.data().name
+            console.log(otherUserName)
+            var commentData = {
+              text: doc.data().comment,
+              userID: otherUserID,
+              userName: otherUserName + "さん",
+              time: this.formatDate(new Date(doc.data().time.seconds * 1000)),
+            }
+            this.comments.push(commentData)
+          }
+        })
       });
     })
   },
@@ -92,6 +101,14 @@ export default {
       var h = ('00' + dt.getHours()).slice(-2)
       var min = ('00' + dt.getMinutes()).slice(-2)
       return (y + '/' + m + '/' + d + ' ' + h + ':' + min)
+    },
+    toProfilePage: function(userID){
+      if(this.$route.path == "/profile"){
+        // ページリロード
+        // this.$router.go({ name: 'ProfilePage' })
+      } else{
+        this.$router.push({name: 'ProfilePage', params: {userID: userID}});
+      }
     },
   },
 }

--- a/src/components/Details/DetailsPage.vue
+++ b/src/components/Details/DetailsPage.vue
@@ -3,8 +3,8 @@
     <CustomHeader/>
     <b-container id="contents-container">
     <!-- 投稿者情報蘭 -->
-      <div v-on:click="toProfilePage" id="user-text-container">
-          <div id="user-name-text"> {{contributor.name}} {{periodOfGitHub}}</div>
+      <div v-on:click="toProfilePage" id="user-text-container" class="h5">
+          <div id="user-name-text"> ユーザー名 : {{contributor.name}} <br> {{periodOfGitHub}}</div>
       </div> 
       <!-- {{contributor}} -->
       <!-- {{periodOfGitHub}} -->
@@ -325,6 +325,10 @@ export default {
   padding: 30px;
   margin-top: 30px;
   background-color: #FFFFFF;
+}
+
+#user-text-container{
+  cursor: pointer;
 }
 
 .section-container {

--- a/src/components/Details/DetailsPage.vue
+++ b/src/components/Details/DetailsPage.vue
@@ -3,8 +3,11 @@
     <CustomHeader/>
     <b-container id="contents-container">
     <!-- 投稿者情報蘭 -->
-      {{contributor}}
-      {{periodOfGitHub}}
+      <div v-on:click="toProfilePage" id="user-text-container">
+          <div id="user-name-text"> {{contributor.name}} {{periodOfGitHub}}</div>
+      </div> 
+      <!-- {{contributor}} -->
+      <!-- {{periodOfGitHub}} -->
       <!-- タイトル欄 -->
       <div class="title-container">
         <div v-if="title != undefined" class="h1">{{title}}</div>
@@ -59,7 +62,7 @@ export default {
       candidate: "",
       selectedIndex: "",
       docID: "",
-      contributor: "",
+      contributor: [],
       periodOfGitHub: "",
       pollOfUser: 0,
       userExists: false,
@@ -94,12 +97,13 @@ export default {
     // 投稿のタイトル・詳細・投稿者を取得
     ref.get().then(doc => {
       if(doc.exists){
+        this.contributor.userID = doc.data().userID
         this.title = doc.data().title
         this.description = doc.data().description
         db.collection("Users").doc(doc.data().userID)
         .get().then(doc => {
           if(doc.exists){
-            this.contributor = doc.data().name
+            this.contributor.name = doc.data().name
             var createTime = doc.data().createAt.seconds
             var now = new Date()
             var milliDiffTime = now.getTime() - new Date(createTime * 1000).getTime()
@@ -303,7 +307,15 @@ export default {
           }
         })
       })
-    }
+    },
+    toProfilePage: function(){
+      if(this.$route.path == "/profile"){
+        // ページリロード
+        // this.$router.go({ name: 'ProfilePage' })
+      } else{
+        this.$router.push({name: 'ProfilePage', params: {userID: this.contributor.userID}});
+      }
+    },
   },
 }
 </script>

--- a/src/components/Profile/ProfilePage.vue
+++ b/src/components/Profile/ProfilePage.vue
@@ -47,6 +47,9 @@ export default {
       periodOfGitHub: "",
     }
   },
+  props:[
+    "userID"
+  ],
   computed:{
     getUserName(){
       return this.$store.getters.userName
@@ -61,7 +64,7 @@ export default {
   mounted: function(){
     // ユーザー名の取得
     this.userName = this.getUserName
-    var userID = this.getUserID
+    var userID = this.userID
     // GitHub歴の取得
     this.periodOfGitHub = this.getPeriodOfGitHub
     //自分の投稿一覧を取得する

--- a/src/components/Profile/ProfilePage.vue
+++ b/src/components/Profile/ProfilePage.vue
@@ -62,11 +62,20 @@ export default {
     }
   },
   mounted: function(){
-    // ユーザー名の取得
-    this.userName = this.getUserName
+    console.log(this.userID)
+    db.collection("Users").doc(this.userID).get().then(doc => {
+      if(doc.exists){
+        // ユーザー名の取得
+        this.userName = doc.data().name
+        // GitHub歴の取得
+        var now = new Date()
+        var milliDiffTime = now.getTime() - new Date(doc.data().createAt.seconds * 1000).getTime()
+        var diffYear = Math.floor(milliDiffTime / 1000 / 60 / 60 / 24 / 365)
+        this.periodOfGitHub = diffYear
+      }  
+    })
+    // ユーザーIDの取得
     var userID = this.userID
-    // GitHub歴の取得
-    this.periodOfGitHub = this.getPeriodOfGitHub
     //自分の投稿一覧を取得する
     var ref = db.collection('Questions').orderBy('time', 'desc')
     var staredRef = db.collection("Users").doc(userID).collection("Questions")

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,6 +30,7 @@ export default new Router({
       path: '/profile',
       name: 'ProfilePage',
       component: ProfilePage,
+      props: true
     },
   ]
 })


### PR DESCRIPTION
# バックログアイテムの情報
close #124 

作成者：@Yamakatsu63

## タスク
- [x] プロフィールページへの遷移時にUserIDをパラメータとして渡すように変更
- [x] 詳細ページのユーザー名からパラメータを渡してプロフィールページに遷移させる